### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,25 @@
 API_BASE_URL="<INSERT BACKEND URL HERE>"
 ```
 
+Example of configuration file:
+
+```
+API_BASE_URL="http://localhost:8080/api"
+```
+
 - create `.env` file in `wrighter-server` with
 
 ```
 DATABASE_URL="<INSERT DB URL HERE>"
 SECRET_KEY="<SOME SECRET>"
 COOKIE_SECRET="<COOKIE SECRET>"
+```
+Example of configuration file:
+
+```
+DATABASE_URL="mysql://wrighter_user:secrete_wrighter_pass@127.0.0.1:3306/wrighter_db"
+SECRET_KEY="SECRETkeyforwrighterapplication"
+COOKIE_SECRET="SECRETCookieforwrighterapplication"
 ```
 
 - from the root directory, run `yarn dev`, it would concurrently run both the server and client


### PR DESCRIPTION
I added example configuration because I think that users had to know that API_BASE_URL need the /api at the end, I try one day to execute before I discover that I need to add it at the end.
I also had problem with mysql in a container but it's prisma problem, when mysql run in a docker the configured user need the permission to create the shadow database, if you think it can be usefull for someone else run it in a docker I add the commands in an another update or I can open an Issue and explain it.
Regards
Alex